### PR TITLE
Add browser support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,7 @@
 
 /**
- * Expose `Emitter`.
- */
-
-module.exports = Emitter;
-
-/**
  * Initialize a new `Emitter`.
- * 
+ *
  * @api public
  */
 
@@ -101,7 +95,7 @@ Emitter.prototype.off = function(event, fn){
  *
  * @param {String} event
  * @param {Mixed} ...
- * @return {Emitter} 
+ * @return {Emitter}
  */
 
 Emitter.prototype.emit = function(event){
@@ -142,3 +136,12 @@ Emitter.prototype.hasListeners = function(event){
   return !! this.listeners(event).length;
 };
 
+/**
+ * Expose `Emitter`.
+ */
+
+if ('undefined' == typeof exports) {
+  window.Emitter = Emitter;
+} else {
+  module.exports = Emitter;
+}


### PR DESCRIPTION
Adds browser support so libraries like [superagent](https://github.com/visionmedia/superagent), which depend on emitter, can continue to function in the browser.

It looks like superagent will also need an update as well to support this: https://github.com/visionmedia/superagent/blob/master/lib/superagent.js#L11
