### PR TITLE
Add indexof dependency of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "emitter",
   "description": "Event emitter",
   "version": "1.0.0",
+  "dependencies": {
+    "indexof": "*"
+  },
   "devDependencies": {
     "mocha": "*",
     "should": "*"


### PR DESCRIPTION
Right now if you want to use `component/emitter` server side, it will break unless you install its dependency `indexof` manually.
