### PR TITLE
emitter.off(event, undefined) should remove all listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ Emitter.prototype.removeAllListeners = function(event, fn){
   if (!callbacks) return this;
 
   // remove all handlers
-  if (1 == arguments.length) {
+  if (undefined == arguments.length) {
     delete this._callbacks[event];
     return this;
   }

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -104,7 +104,24 @@ describe('Emitter', function(){
       emitter.emit('tobi');
       called.should.be.false;
     });
-  })
+
+    it('should remove all listeners when `fn` is undefined', function() {
+      var emitter = new Emitter;
+      var calls = [];
+
+      function one() { calls.push('one'); }
+      function two() { calls.push('two'); }
+
+      emitter.on('foo', one);
+      emitter.on('foo', two);
+      emitter.off('foo', undefined);
+
+      emitter.emit('foo');
+      emitter.emit('foo');
+
+      calls.should.eql([]);
+    });
+  });
 
   describe('.off(event)', function(){
     it('should remove all listeners for an event', function(){


### PR DESCRIPTION
Allows for better integration with frameworks. 

I ran into it when unsubscribing from a reactive event, because we pass `fn` into `.off(event, fn)` regardless of if it's defined or not.
