### PR TITLE
[Bug] Instances share _callbacks object when an emitter method is called on the prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function mixin(obj) {
  */
 
 Emitter.prototype.on = function(event, fn){
-  this._callbacks = this._callbacks || {};
+  this._callbacks = this.hasOwnProperty('_callbacks') && this._callbacks || {};
   (this._callbacks[event] = this._callbacks[event] || [])
     .push(fn);
   return this;
@@ -64,7 +64,7 @@ Emitter.prototype.on = function(event, fn){
 
 Emitter.prototype.once = function(event, fn){
   var self = this;
-  this._callbacks = this._callbacks || {};
+  this._callbacks = this.hasOwnProperty('_callbacks') && this._callbacks || {};
 
   function on() {
     self.off(event, on);
@@ -89,7 +89,7 @@ Emitter.prototype.once = function(event, fn){
 Emitter.prototype.off =
 Emitter.prototype.removeListener =
 Emitter.prototype.removeAllListeners = function(event, fn){
-  this._callbacks = this._callbacks || {};
+  this._callbacks = this.hasOwnProperty('_callbacks') && this._callbacks || {};
 
   // all
   if (0 == arguments.length) {
@@ -122,7 +122,7 @@ Emitter.prototype.removeAllListeners = function(event, fn){
  */
 
 Emitter.prototype.emit = function(event){
-  this._callbacks = this._callbacks || {};
+  this._callbacks = this.hasOwnProperty('_callbacks') && this._callbacks || {};
   var args = [].slice.call(arguments, 1)
     , callbacks = this._callbacks[event];
 
@@ -145,7 +145,7 @@ Emitter.prototype.emit = function(event){
  */
 
 Emitter.prototype.listeners = function(event){
-  this._callbacks = this._callbacks || {};
+  this._callbacks = this.hasOwnProperty('_callbacks') && this._callbacks || {};
   return this._callbacks[event] || [];
 };
 

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -37,6 +37,25 @@ describe('Emitter', function(){
 
       calls.should.eql([ 'one', 1, 'two', 1, 'one', 2, 'two', 2 ]);
     })
+
+    it('should not share callbacks across instances', function(){
+      var calls = []
+      Custom.prototype.on('foo', function(){
+        calls.push('proto')
+      })
+      var a = new Custom()
+      a.on('foo', function(){
+        calls.push('a')
+      })
+      var b = new Custom()
+      b.on('foo', function(){
+        calls.push('b')
+      })
+
+      b.emit('foo')
+      calls.should.eql(['b'])
+
+    })
   })
 
   describe('.once(event, fn)', function(){


### PR DESCRIPTION
Currently there's a bug/unexpected behavior if you use any of the `Emitter` methods on a prototype and then try and use them on instances. What happens is because `.prototype.on` will create a `_callbacks` object on the prototype, all instances will now share the same `._callbacks` object which is not desirable behavior. 

This patch simply checks .hasOwnProperty when calling emitter methods to make sure the instance has it's own callback collection. (Bug was introdroduced at https://github.com/component/emitter/commit/c3fc7f5aa851278daf7b272a9c70fbd734493aca)

For example:

``` javascript
function Custom() {
  Emitter.call(this)
}

Custom.prototype.__proto__ = Emitter.prototype;

var calls = []
var a = new Custom()
a.on('foo', function(){
  calls.push('a')
})
var b = new Custom()
b.on('foo', function(){
  calls.push('b')
})

b.emit('foo')
console.log(calls) // will be ['proto', 'a', 'b'] instead of simply ['b']. Emitting an event on one instance now triggers listeners on all instances
```
