### PR TITLE
Make _callbacks property non-enumerable

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function init(obj) {
     obj._callbacks = {};
   }
 }
+
 /**
  * Mixin the emitter properties.
  *
@@ -81,8 +82,7 @@ Emitter.prototype.on = function(event, fn){
 
 Emitter.prototype.once = function(event, fn){
   var self = this;
-  if(!this.hasOwnProperty('_callbacks')) init(this);
-
+  
   function on() {
     self.off(event, on);
     fn.apply(this, arguments);
@@ -106,7 +106,7 @@ Emitter.prototype.once = function(event, fn){
 Emitter.prototype.off =
 Emitter.prototype.removeListener =
 Emitter.prototype.removeAllListeners = function(event, fn){
-  if(!this.hasOwnProperty('_callbacks')) init(this);
+  if(!this.hasOwnProperty('_callbacks')) return;
   // all
   if (0 == arguments.length) {
     this._callbacks = {};
@@ -138,7 +138,7 @@ Emitter.prototype.removeAllListeners = function(event, fn){
  */
 
 Emitter.prototype.emit = function(event){
-  if(!this.hasOwnProperty('_callbacks')) init(this);
+  if(!this.hasOwnProperty('_callbacks')) return;
   var args = [].slice.call(arguments, 1)
     , callbacks = this._callbacks[event];
 
@@ -161,7 +161,7 @@ Emitter.prototype.emit = function(event){
  */
 
 Emitter.prototype.listeners = function(event){
-  if(!this.hasOwnProperty('_callbacks')) init(this);
+  if(!this.hasOwnProperty('_callbacks')) return [];
   return this._callbacks[event] || [];
 };
 

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -37,6 +37,25 @@ describe('Emitter', function(){
 
       calls.should.eql([ 'one', 1, 'two', 1, 'one', 2, 'two', 2 ]);
     })
+    
+    it('should not share callbacks across instances', function(){
+      var calls = []
+      Custom.prototype.on('foo', function(){
+        calls.push('proto')
+      })
+      var a = new Custom()
+      a.on('foo', function(){
+        calls.push('a')
+      })
+      var b = new Custom()
+      b.on('foo', function(){
+        calls.push('b')
+      })
+
+      b.emit('foo')
+      calls.should.eql(['b'])
+
+    })
   })
 
   describe('.once(event, fn)', function(){


### PR DESCRIPTION
Just a simple change that makes the ._callbacks property non-enumerable if possible.
