### PR TITLE
Null check before applying callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,9 @@ Emitter.prototype.emit = function(event){
   if (callbacks) {
     callbacks = callbacks.slice(0);
     for (var i = 0, len = callbacks.length; i < len; ++i) {
-      callbacks[i].apply(this, args);
+        if(callbacks[i]) {
+            callbacks[i].apply(this, args);
+        }
     }
   }
 


### PR DESCRIPTION
Added check to ensure that the item in the callbacks array is not
null/undefined before calling apply.
