### PR TITLE
Add license to Readme (same format as the other components)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,3 +68,7 @@ Emitter(User.prototype);
 ### Emitter#hasListeners(event)
 
   Check if this emitter has `event` handlers.
+
+## License
+
+MIT


### PR DESCRIPTION
As discussed - decided to add it to the README so it's consistent with the other components (the full license is included in component/component).

Thanks in advance!
