### PR TITLE
Add support for objects as event listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,27 @@ function mixin(obj) {
 }
 
 /**
+ * Applies a callback which may have been either as a function, in which case
+ * the `fnOrObj` parameter is called directly, or an object implementing the
+ * `handleEvent` method, in which case `fnOrObj.handleEvent` is called.
+ *
+ * @param {String} event
+ * @param {Object} fnOrObj
+ * @param {Object} thisObj
+ * @param {Array} args
+ * @api private
+ */
+
+function applyCallback(event, fnOrObj, thisObj, args) {
+  if (typeof fnOrObj === 'function') {
+    fnOrObj.apply(thisObj, args);
+  } else if (typeof fnOrObj.handleEvent === 'function') {
+    if (!(args instanceof Array)) args = [].slice.call(args);
+    fnOrObj.handleEvent.apply(fnOrObj, [event].concat(args));
+  }
+}
+
+/**
  * Listen on the given `event` with `fn`.
  *
  * @param {String} event
@@ -63,7 +84,7 @@ Emitter.prototype.once = function(event, fn){
 
   function on() {
     self.off(event, on);
-    fn.apply(this, arguments);
+    applyCallback(event, fn, this, arguments);
   }
 
   on.fn = fn;
@@ -131,7 +152,7 @@ Emitter.prototype.emit = function(event){
   if (callbacks) {
     callbacks = callbacks.slice(0);
     for (var i = 0, len = callbacks.length; i < len; ++i) {
-      callbacks[i].apply(this, args);
+      applyCallback(event, callbacks[i], this, args);
     }
   }
 

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -37,6 +37,22 @@ describe('Emitter', function(){
 
       calls.should.eql([ 'one', 1, 'two', 1, 'one', 2, 'two', 2 ]);
     })
+
+    it('should allow listeners implementing handleEvent', function(){
+      var emitter = new Emitter;
+      var results = [];
+
+      var listener = {
+        handleEvent: function(event, val){
+          results = [event, val, this === listener];
+        }
+      };
+
+      emitter.on('foo', listener);
+
+      emitter.emit('foo', 1);
+      results.should.eql(['foo', 1, true]);
+    })
   })
 
   describe('.once(event, fn)', function(){
@@ -54,6 +70,29 @@ describe('Emitter', function(){
       emitter.emit('bar', 1);
 
       calls.should.eql([ 'one', 1 ]);
+    })
+
+    it('should allow listeners implementing handleEvent', function(){
+      var emitter = new Emitter
+      var results = []
+        , called;
+
+      var listener = {
+        handleEvent: function(event, val){
+          results = [event, val, this === listener];
+          called = true;
+        }
+      };
+
+      emitter.once('foo', listener);
+
+      emitter.emit('foo', 1);
+      called.should.be.true;
+      results.should.eql(['foo', 1, true]);
+
+      called = false;
+      emitter.emit('foo', 1);
+      called.should.be.false;
     })
   })
 


### PR DESCRIPTION
The benefit is that you can pass an instance of a class and the sole requirement for the provided object is to implement the `handleEvent` method, much like the W3C DOM `EventListener` interface. The benefit here is that you can easily add and remove event listeners without preserving pointers to functions bound to a given object. The `handleEvent` method is passed the `event` as an extra first parameter.
