### PR TITLE
remove event if function code matches

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ Emitter.prototype.removeEventListener = function(event, fn){
   var cb;
   for (var i = 0; i < callbacks.length; i++) {
     cb = callbacks[i];
-    if (cb === fn || cb.fn === fn) {
+    if (cb === fn || cb.fn === fn || cb.toString() === fn.toString()) {
       callbacks.splice(i, 1);
       break;
     }


### PR DESCRIPTION
this fixes a problem i was having with socket.io for ex:
socket.on("blah", this.eventhandler)
socket.removeListener("blah", this.eventhandler)
