### PR TITLE
modified .npmignore to include .gitignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
+.gitignore
 node_modules
 test


### PR DESCRIPTION
added .gitignore to .npmignore. This prevents the .gitignore file from being downloaded when this module is installed using npm.

This solves the following issue:
socket.io uses this module. When a socket.io module app is deployed to Heroku using git, the indexof module is omitted (because of the .gitignore). This causes the socket.io application to crash. Adding .gitignore to .npmignore will solve this problem 
