### PR TITLE
Fix adding events which have same names with methods of Object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function mixin(obj) {
 Emitter.prototype.on =
 Emitter.prototype.addEventListener = function(event, fn){
   this._callbacks = this._callbacks || {};
-  (this._callbacks[event] = this._callbacks[event] || [])
+  (this._callbacks['$' + event] = this._callbacks['$' + event] || [])
     .push(fn);
   return this;
 };
@@ -91,12 +91,12 @@ Emitter.prototype.removeEventListener = function(event, fn){
   }
 
   // specific event
-  var callbacks = this._callbacks[event];
+  var callbacks = this._callbacks['$' + event];
   if (!callbacks) return this;
 
   // remove all handlers
   if (1 == arguments.length) {
-    delete this._callbacks[event];
+    delete this._callbacks['$' + event];
     return this;
   }
 
@@ -123,7 +123,7 @@ Emitter.prototype.removeEventListener = function(event, fn){
 Emitter.prototype.emit = function(event){
   this._callbacks = this._callbacks || {};
   var args = [].slice.call(arguments, 1)
-    , callbacks = this._callbacks[event];
+    , callbacks = this._callbacks['$' + event];
 
   if (callbacks) {
     callbacks = callbacks.slice(0);
@@ -145,7 +145,7 @@ Emitter.prototype.emit = function(event){
 
 Emitter.prototype.listeners = function(event){
   this._callbacks = this._callbacks || {};
-  return this._callbacks[event] || [];
+  return this._callbacks['$' + event] || [];
 };
 
 /**

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -37,6 +37,24 @@ describe('Emitter', function(){
 
       calls.should.eql([ 'one', 1, 'two', 1, 'one', 2, 'two', 2 ]);
     })
+
+    it('should add listeners for events which are same names with methods of Object.prototype', function(){
+      var emitter = new Emitter;
+      var calls = [];
+
+      emitter.on('constructor', function(val){
+        calls.push('one', val);
+      });
+
+      emitter.on('__proto__', function(val){
+        calls.push('two', val);
+      });
+
+      emitter.emit('constructor', 1);
+      emitter.emit('__proto__', 2);
+
+      calls.should.eql([ 'one', 1, 'two', 2 ]);
+    })
   })
 
   describe('.once(event, fn)', function(){


### PR DESCRIPTION
Usually this is not so much problem but anyway supporting any events would be nice.
Especially for Firefox which has `watch` and `unwatch` as methods of Object. 

Related: https://github.com/Automattic/socket.io/issues/1983