### PR TITLE
Stop event propagation inside handler.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,7 @@ Emitter(User.prototype);
 ### Emitter#on(event, fn)
 
   Register an `event` handler `fn`.
+  Set `this.handled = true` inside handler `fn` to stop event propagation.
 
 ### Emitter#once(event, fn)
 

--- a/index.js
+++ b/index.js
@@ -127,8 +127,15 @@ Emitter.prototype.emit = function(event){
 
   if (callbacks) {
     callbacks = callbacks.slice(0);
+
+    this.handled = false;
     for (var i = 0, len = callbacks.length; i < len; ++i) {
       callbacks[i].apply(this, args);
+
+      if (this.handled) {
+        this.handled = false;
+        break;
+      }
     }
   }
 

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -201,6 +201,29 @@ describe('Emitter', function(){
       })
     })
   })
+
+  describe('this.handled = true', function () {
+    it('should stop emitting when listener handles an event', function(){
+      var emitter = new Emitter;
+      var calls = [];
+
+      emitter.on('foo', function(val){
+        calls.push('one', val);
+        if (val > 1) {
+          this.handled = true;
+        }
+      });
+
+      emitter.on('foo', function(val){
+        calls.push('two', val);
+      });
+
+      emitter.emit('foo', 1);
+      emitter.emit('foo', 2);
+
+      calls.should.eql([ 'one', 1, 'two', 1, 'one', 2 ]);
+    })
+  })
 })
 
 describe('Emitter(obj)', function(){


### PR DESCRIPTION
I'd like to be able to break out of the handler loop if a handler specifies that it has handled the event.
This PR lets a handler `fn` set `this.handled = true` that will break out of the emit loop.

``` js
emitter.on('login', function (user) {
  if (user.username === 'doowb' && user.password === 'password') {
    this.handled = true;
    this.user = user;
  }
});

emitter.on('login', function (user) {
  this.error = 'Invalid username and/or password';
});

emitter.emit('login', {username: 'doowb', password: 'invalid'});
console.log(emitter.error);
//=> Invalid username and/or password

emitter.emit('login', {username: 'doowb', password: 'password'});
console.log(emitter.user);
//=> {username: 'doowb', password: 'password'}
```
