### PR TITLE
Few changes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,9 +12,8 @@ $ component install component/emitter
 
 ### Emitter(obj)
 
-  The `Emitter` may also be used as a mixin. For example
-  a "plain" object may become an emitter, or you may
-  extend an existing prototype.
+  The `Emitter` may also be used as a mixin. 
+  For example a "plain" object may become an emitter, or you may extend an existing prototype.
 
   As an `Emitter` instance:
 
@@ -41,23 +40,21 @@ var Emitter = require('emitter');
 Emitter(User.prototype);
 ```
 
-### Emitter#on(event, fn)
+### Emitter#on(event, fn) | Emitter#addEventListener(event, fn) 
 
   Register an `event` handler `fn`.
 
 ### Emitter#once(event, fn)
 
-  Register a single-shot `event` handler `fn`,
-  removed immediately after it is invoked the
-  first time.
+  Register a single-shot `event` handler `fn`, removed immediately after it is invoked the first time.
 
-### Emitter#off(event, fn)
+### Emitter#off(event, fn) | Emitter#removeListener(event, fn) | Emitter#removeAllListeners(event, fn) | Emitter#removeEventListener(event, fn)
 
   * Pass `event` and `fn` to remove a listener.
   * Pass `event` to remove all listeners on that event.
   * Pass nothing to remove all listeners on all events.
 
-### Emitter#emit(event, ...)
+### Emitter#emit(event, ...) | Emitter#dispatchEvent(event, ...) | Emitter#trigger(event, ...) | Emitter#triggerHandler(event, fn) 
 
   Emit an `event` with variable option args.
 

--- a/index.js
+++ b/index.js
@@ -121,9 +121,19 @@ Emitter.prototype.removeEventListener = function(event, fn){
  */
 
 Emitter.prototype.emit = function(event){
-  this._callbacks = this._callbacks || {};
+  if (!this._callbacks) {
+    return;
+  }
+
+  var eventType = event.type ? event.type : event;
   var args = [].slice.call(arguments, 1)
-    , callbacks = this._callbacks['$' + event];
+    , callbacks = this._callbacks['$' + eventType];
+  if (event.type) {
+    event.target = this;
+    event.extraParams = event.extraParams || args.slice(0);
+    event.data = event.data || args.slice(0);
+    args.splice(0, 0, event);
+  }
 
   if (callbacks) {
     callbacks = callbacks.slice(0);

--- a/index.js
+++ b/index.js
@@ -120,6 +120,9 @@ Emitter.prototype.removeEventListener = function(event, fn){
  * @return {Emitter}
  */
 
+Emitter.prototype.trigger = 
+Emitter.prototype.triggerHandler = 
+Emitter.prototype.dispatchEvent = 
 Emitter.prototype.emit = function(event){
   if (!this._callbacks) {
     return;

--- a/index.js
+++ b/index.js
@@ -131,6 +131,16 @@ Emitter.prototype._removeOneEventListener = function(event, fn){
   return this;
 };
 
+var ALL = "*";
+var callAll = function(callbacks, target, args) {
+  if (!callbacks) {
+    return;
+  }
+  callbacks = callbacks.slice(0);
+  for (var i = 0, len = callbacks.length; i < len; ++i) {
+    callbacks[i].apply(target, args);
+  }
+}
 /**
  * Emit `event` with the given args.
  *
@@ -147,23 +157,20 @@ Emitter.prototype.emit = function(event){
     return;
   }
 
-  var eventType = event.type ? event.type : event;
-  var args = [].slice.call(arguments, 1)
-    , callbacks = this._callbacks['$' + eventType];
+  // remove the first argument which is the event type or the event object
+  var args = [].slice.call(arguments, 1);
+  var eventType = event;
   if (event.type) {
+    // in case we have to emit an event object
+    eventType = event.type;
     event.target = this;
-    event.extraParams = event.extraParams || args.slice(0);
-    event.data = event.data || args.slice(0);
+    event.extraParams = event.extraParams || args;
+    event.data = event.data || args;
     args.splice(0, 0, event);
   }
 
-  if (callbacks) {
-    callbacks = callbacks.slice(0);
-    for (var i = 0, len = callbacks.length; i < len; ++i) {
-      callbacks[i].apply(this, args);
-    }
-  }
-
+  callAll(this._callbacks['$' + eventType], this, args);
+  callAll(this._callbacks['$' + ALL], this, args);
   return this;
 };
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function mixin(obj) {
   return obj;
 }
 
+var EVENT_SEPARATOR = " ";
 /**
  * Listen on the given `event` with `fn`.
  *
@@ -41,12 +42,18 @@ function mixin(obj) {
 
 Emitter.prototype.on =
 Emitter.prototype.addEventListener = function(event, fn){
-  this._callbacks = this._callbacks || {};
-  (this._callbacks['$' + event] = this._callbacks['$' + event] || [])
-    .push(fn);
-  return this;
+  event = event.push ? event : event.split(EVENT_SEPARATOR);
+  for (var i = 0, len = event.length; i < len; i++) {
+    this._addOneEventListener(event[i], fn)
+  }
 };
 
+Emitter.prototype._addOneEventListener = function(event, fn) {
+  this._callbacks = this._callbacks || {};
+  (this._callbacks['$' + event] = this._callbacks['$' + event] || [])
+      .push(fn);
+  return this;  
+};
 /**
  * Adds an `event` listener that will be invoked a single
  * time then automatically removed.
@@ -82,11 +89,23 @@ Emitter.prototype.off =
 Emitter.prototype.removeListener =
 Emitter.prototype.removeAllListeners =
 Emitter.prototype.removeEventListener = function(event, fn){
-  this._callbacks = this._callbacks || {};
-
+  if (!this._callbacks) {
+    return this;
+  }
   // all
   if (0 == arguments.length) {
     this._callbacks = {};
+    return this;
+  }
+  event = event.push ? event : event.split(EVENT_SEPARATOR);
+  for (var i = 0, len = event.length; i < len; i++) {
+    this._removeOneEventListener(event[i], fn)
+  }
+  return this;
+};
+
+Emitter.prototype._removeOneEventListener = function(event, fn){
+  if (!this._callbacks) {
     return this;
   }
 
@@ -95,7 +114,7 @@ Emitter.prototype.removeEventListener = function(event, fn){
   if (!callbacks) return this;
 
   // remove all handlers
-  if (1 == arguments.length) {
+  if (!fn) {
     delete this._callbacks['$' + event];
     return this;
   }

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -211,3 +211,15 @@ describe('Emitter(obj)', function(){
     proto.emit('something');
   })
 })
+describe('event object', function() {
+  it('should emit event object', function(done){
+    var emitter = new Emitter;
+    var event;
+    emitter.on('foo', function(evt) { event = evt;});
+    emitter.emit({"type": "foo"});
+    event.should.be.not.null;
+    event.type.should.eql("foo");
+    event.target.should.eql(emitter);
+    done();
+  })
+})

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -250,3 +250,19 @@ describe('multiple events', function(){
     done();
   });
 })
+
+describe('wildcard events', function(){
+  it('should run *', function(done){
+    var proto = {};
+    Emitter(proto);
+    var runs = [];
+    proto.on('*', function() {runs.push("*");});
+    proto.on('foo', function() {runs.push("foo");});
+    proto.on('bar', function() {runs.push("bar");});
+    proto.emit('foo');
+    proto.emit('bar');
+    proto.emit("another");
+    runs.should.eql(["foo", "*", "bar", "*", "*"]);
+    done();
+  })
+})

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -223,3 +223,30 @@ describe('event object', function() {
     done();
   })
 })
+describe('multiple events', function(){
+  it('should add multiple events', function(done){
+    var proto = {};
+    Emitter(proto);
+    var runs = [];
+    proto.on('foo bar', function() { runs.push("foo");});
+    proto.on('bar', function() { runs.push("bar");});
+    proto.emit('foo');
+    runs.should.eql(["foo"]);
+    proto.emit('bar');
+    runs.should.eql(["foo", "foo", "bar"]);
+    done();
+  });
+  it('should remove multiple events', function(done){
+    var proto = {};
+    Emitter(proto);
+    var runs = [];
+    proto.on('foo bar', function() { runs.push("foo");});
+    proto.on('baz', function() { runs.push("bar");});
+    proto.off("bar baz");
+    proto.emit('foo');
+    runs.should.eql(["foo"]);
+    proto.emit('bar');
+    runs.should.eql(["foo"]);
+    done();
+  });
+})


### PR DESCRIPTION
Synonim for emit: trigger
Multiple events, e.g. emitter.on("foo bar", fn)
Wildcard events, e.g. emitter.on("*", fn). Fixes #61.
Ability to emit an event object instead of just an event name.

I created separate branches for any of these changes, in case you want to pull only one of them.
