### PR TITLE
Prevent v8 deopt when using [].slice.call(arguments)

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,8 +122,13 @@ Emitter.prototype.removeEventListener = function(event, fn){
 
 Emitter.prototype.emit = function(event){
   this._callbacks = this._callbacks || {};
-  var args = [].slice.call(arguments, 1)
+
+  var args = new Array(arguments.length - 1)
     , callbacks = this._callbacks['$' + event];
+
+  for (var i = 1; i < arguments.length; i++) {
+    args[i - 1] = arguments[i];
+  }
 
   if (callbacks) {
     callbacks = callbacks.slice(0);


### PR DESCRIPTION
As is well-known, accessing anything other than `arguments[index]` or `arguments.length` causes deopt in V8, leading to a [20x performance disparity](https://jsperf.com/copy-fn-arguments-test) versus copying in a for loop.

As an event emitter lib should be as fast as possible so other libraries can build on top of it, I thought this would be a meaningful change. Other libraries that may be processing a very large number of messages per second (like Primus) depend on this library.