### PR TITLE
Avoid memory leaks by removing event arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,13 @@ Emitter.prototype.removeEventListener = function(event, fn){
       break;
     }
   }
+
+  // Remove event specific arrays for event types that no
+  // one is subscribed for to avoid memory leak.
+  if (callbacks.length === 0) {
+    delete this._callbacks['$' + event];
+  }
+
   return this;
 };
 

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -142,6 +142,32 @@ describe('Emitter', function(){
 
       calls.should.eql([]);
     })
+
+    it('should remove event array to avoid memory leak', function() {
+      var emitter = new Emitter;
+      var calls = [];
+
+      function cb() {}
+
+      emitter.on('foo', cb);
+      emitter.off('foo', cb);
+
+      emitter._callbacks.should.not.have.property('$foo');
+    })
+
+    it('should only remove the event array when the last subscriber unsubscribes', function() {
+      var emitter = new Emitter;
+      var calls = [];
+
+      function cb1() {}
+      function cb2() {}
+
+      emitter.on('foo', cb1);
+      emitter.on('foo', cb2);
+      emitter.off('foo', cb1);
+
+      emitter._callbacks.should.have.property('$foo');
+    })
   })
 
   describe('.off()', function(){


### PR DESCRIPTION
When subscribing and then unsubscribing from many different types of events,
it can be observed that the `Emitter._callbacks` object starts to grow.
This happens because, when unsubscribing, the event specific event array
is not removed when the last subscriber unsubscribes.
