### PR TITLE
Expose Emitter if module exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@
  * Expose `Emitter`.
  */
 
-module.exports = Emitter;
+if (typeof module !== 'undefined') {
+  module.exports = Emitter;
+}
 
 /**
  * Initialize a new `Emitter`.


### PR DESCRIPTION
Enables client side use.

Same than #67 but cleaner.