### PR TITLE
Each event callback should always get executed regardless of others' error

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,11 @@ Emitter.prototype.emit = function(event){
   if (callbacks) {
     callbacks = callbacks.slice(0);
     for (var i = 0, len = callbacks.length; i < len; ++i) {
-      callbacks[i].apply(this, args);
+      try {
+        callbacks[i].apply(this, args);
+      } catch (exception) {
+        console.error(exception);
+      }
     }
   }
 


### PR DESCRIPTION
# Issue

If some same name events are register and one of the callbacks gets an error when executing, the rest wouldn't be get executed. For example,

```js
var emitter = new Emitter;

emitter.on('foo', function() {
  console.log('foo1');
  throw new Error('foo1'); // or any other error occurs
});

emitter.on('foo', function() {
  console.log('foo2');
});

emitter.emit('foo');

// foo1
// uncaught error: foo1
```

The second registered event callback will not be executed.

Actually, it would be better that the registered events should not depend on each other and all the callbacks should be fired without interruption.

Look at the related issue #72 .

# Solution

Apply `try...catch` to each callback execution.

```js
for (var i = 0, len = callbacks.length; i < len; ++i) {
  try {
    callbacks[i].apply(this, args);
  } catch (exception) {
    console.error(exception);
  }
}
```
