### PR TITLE
Delete all handler of the same function

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,11 +104,10 @@ Emitter.prototype.removeEventListener = function(event, fn){
 
   // remove specific handler
   var cb;
-  for (var i = 0; i < callbacks.length; i++) {
+  for (var i = callbacks.length - 1; i >= 0; i--) {
     cb = callbacks[i];
     if (cb === fn || cb.fn === fn) {
       callbacks.splice(i, 1);
-      break;
     }
   }
   return this;


### PR DESCRIPTION
Because “on“ method can push many of the same functions.