### PR TITLE
Enabling adding multiple events to a callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,26 @@ Emitter.prototype.addEventListener = function(event, fn){
 };
 
 /**
+ * Listen on a list of given `events` with `fn`.
+ *
+ * @param {Array} events
+ * @param {Function} fn
+ * @return {Emitter}
+ * @api public
+ */
+
+Emitter.prototype.addEventsListener = function(events, fn){
+  this._callbacks = this._callbacks || {};
+
+  events.forEach(event => {
+    (this._callbacks['$' + event] = this._callbacks['$' + event] || [])
+    .push(fn);
+  })
+  
+  return this;
+};
+
+/**
  * Adds an `event` listener that will be invoked a single
  * time then automatically removed.
  *

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -57,6 +57,24 @@ describe('Emitter', function(){
     })
   })
 
+  describe('.addEventsListener(events, fn)', function(){
+    it('should add listener to multiple events', function(){
+      var emitter = new Emitter;
+      var calls = [];
+
+      emitter.addEventsListener(['foo', 'bar'], function(val){
+        calls.push(val);
+      });
+
+      emitter.emit('foo', 1);
+      emitter.emit('bar', 2);
+      emitter.emit('foo', 2);
+      emitter.emit('bar', 1);
+
+      calls.should.eql([ 1, 2, 2, 1 ]);
+    })
+  })
+
   describe('.once(event, fn)', function(){
     it('should add a single-shot listener', function(){
       var emitter = new Emitter;


### PR DESCRIPTION
# Enabling adding multiple events to a callback

## Problem at hand using [socket.io]()

```javascript
    socket.on('xxxxxx', () => {
      this.performAction1();
    });

    socket.on('yyyyyyy', () => {
      this.performAction1();
    });

    socket.on('zzzzzzzz', ({ value1, value2 }) => {
      this.performAction2(value1, value2);
    });

    socket.on('xzxzxzxzxz', () => {
      this.performAction1();
    });
```

One callback is used for multiple events, whereas an array could be passed.

## Solution

```javascript
    socket.addEventsListener(['xxxxxx', 'xzxzxzxzxz', 'yyyyyyy'], () => {
      this.performAction1();
    });

    socket.on('zzzzzzzz', ({ value1, value2}) => {
      this.performAction2(value1, value2);
    });
```

## Results

 - Lines of code saved
 - No breaking changes

## Issues encountered

I could not find a good keyword to match `on` and add a shortcut, so I did not add one.