### PR TITLE
Only prepare args if there are callbacks to call

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,14 +132,13 @@ Emitter.prototype.removeEventListener = function(event, fn){
 Emitter.prototype.emit = function(event){
   this._callbacks = this._callbacks || {};
 
-  var args = new Array(arguments.length - 1)
-    , callbacks = this._callbacks['$' + event];
-
-  for (var i = 1; i < arguments.length; i++) {
-    args[i - 1] = arguments[i];
-  }
+  var callbacks = this._callbacks['$' + event];
 
   if (callbacks) {
+    var args = new Array(arguments.length - 1);
+    for (var i = 1; i < arguments.length; i++) {
+      args[i - 1] = arguments[i];
+    }
     callbacks = callbacks.slice(0);
     for (var i = 0, len = callbacks.length; i < len; ++i) {
       callbacks[i].apply(this, args);


### PR DESCRIPTION
If an event has no callbacks, then don't do needless work preparing the args array